### PR TITLE
fixing the lab_url for alias

### DIFF
--- a/roles/sriov-prep/defaults/main.yml
+++ b/roles/sriov-prep/defaults/main.yml
@@ -8,7 +8,7 @@ lab_name: scale
 
 alias:
 #lab specific vars, leave default
-  lab_url: "http://quads11.alias.bos.scalelab.redhat.com"
+  lab_url: "http://quads.alias.bos.scalelab.redhat.com/" 
 scale:
 # lab specific vars, leave default
   lab_url: "http://quads.rdu2.scalelab.redhat.com"


### PR DESCRIPTION
The URL for the inventory has changed for the alias lab, fixing that. 